### PR TITLE
Add alwaysShowIcons option

### DIFF
--- a/Editor/HierarchyPlus.cs
+++ b/Editor/HierarchyPlus.cs
@@ -346,13 +346,15 @@ namespace DreadScripts.HierarchyPlus
 			        if (settings.alwaysShowIcons)
 			        {
 			        	iconsAreaWidth = 36;
+			        	return true;
 			        }
 			        else
 			        {
 			        	iconsAreaWidth -= 18;
+			        	return canDraw;
 			    	}
 
-			        return canDraw;
+			        
 		        }
 
 		        if (settings.showGameObjectIcon && CanDrawIcon())

--- a/Editor/HierarchyPlus.cs
+++ b/Editor/HierarchyPlus.cs
@@ -135,7 +135,7 @@ namespace DreadScripts.HierarchyPlus
 						settings.showNonBehaviourIcons.DrawField("Show Non-Toggleable Icons");
 						settings.linkCursorOnHover.DrawField("Link Cursor On Hover");
 						settings.guiXOffset.value = EditorGUILayout.FloatField("Icons X Offset", settings.guiXOffset.value);
-						settings.alwaysShowIcons.DrawField("Show Icons over Names");
+						settings.alwaysShowIcons.DrawField("Display Icons Over Names");
 						using (new GUILayout.VerticalScope())
 						{
 							Foldout(new GUIContent("Hidden Types", "Hover over an icon to see its type name.\nWrite the type name here to hide the icon from the hierarchy view."), ref hiddenIconsFoldout);

--- a/Editor/HierarchyPlus.cs
+++ b/Editor/HierarchyPlus.cs
@@ -133,9 +133,9 @@ namespace DreadScripts.HierarchyPlus
 							settings.useCustomGameObjectIcon.DrawField("Use Custom GameObject Icon");
 						settings.showTransformIcon.DrawField("Show Transform Icon");
 						settings.showNonBehaviourIcons.DrawField("Show Non-Toggleable Icons");
+						settings.alwaysShowIcons.DrawField("Always Render Icons");
 						settings.linkCursorOnHover.DrawField("Link Cursor On Hover");
 						settings.guiXOffset.value = EditorGUILayout.FloatField("Icons X Offset", settings.guiXOffset.value);
-						settings.alwaysShowIcons.DrawField("Show Icons Over Long Names");
 						using (new GUILayout.VerticalScope())
 						{
 							Foldout(new GUIContent("Hidden Types", "Hover over an icon to see its type name.\nWrite the type name here to hide the icon from the hierarchy view."), ref hiddenIconsFoldout);

--- a/Editor/HierarchyPlus.cs
+++ b/Editor/HierarchyPlus.cs
@@ -135,6 +135,7 @@ namespace DreadScripts.HierarchyPlus
 						settings.showNonBehaviourIcons.DrawField("Show Non-Toggleable Icons");
 						settings.linkCursorOnHover.DrawField("Link Cursor On Hover");
 						settings.guiXOffset.value = EditorGUILayout.FloatField("Icons X Offset", settings.guiXOffset.value);
+						settings.alwaysShowIcons.DrawField("Show Icons over Names");
 						using (new GUILayout.VerticalScope())
 						{
 							Foldout(new GUIContent("Hidden Types", "Hover over an icon to see its type name.\nWrite the type name here to hide the icon from the hierarchy view."), ref hiddenIconsFoldout);
@@ -335,14 +336,22 @@ namespace DreadScripts.HierarchyPlus
 		        {
 			        bool dotsOnly = iconsAreaWidth < 36;
 			        bool canDraw = iconsAreaWidth > 18;
-			        if (canDraw && dotsOnly)
+			        if (canDraw && dotsOnly && !settings.alwaysShowIcons)
 			        {
 				        GUI.Label(iconRect, "...", EditorStyles.centeredGreyMiniLabel);
 				        iconsAreaWidth -= 18;
 				        return false;
 			        }
+			        
+			        if (settings.alwaysShowIcons)
+			        {
+			        	iconsAreaWidth = 36;
+			        }
+			        else
+			        {
+			        	iconsAreaWidth -= 18;
+			    	}
 
-			        iconsAreaWidth -= 18;
 			        return canDraw;
 		        }
 

--- a/Editor/HierarchyPlus.cs
+++ b/Editor/HierarchyPlus.cs
@@ -135,7 +135,7 @@ namespace DreadScripts.HierarchyPlus
 						settings.showNonBehaviourIcons.DrawField("Show Non-Toggleable Icons");
 						settings.linkCursorOnHover.DrawField("Link Cursor On Hover");
 						settings.guiXOffset.value = EditorGUILayout.FloatField("Icons X Offset", settings.guiXOffset.value);
-						settings.alwaysShowIcons.DrawField("Display Icons Over Names");
+						settings.alwaysShowIcons.DrawField("Show Icons Over Long Names");
 						using (new GUILayout.VerticalScope())
 						{
 							Foldout(new GUIContent("Hidden Types", "Hover over an icon to see its type name.\nWrite the type name here to hide the icon from the hierarchy view."), ref hiddenIconsFoldout);

--- a/Editor/HierarchyPlus.cs
+++ b/Editor/HierarchyPlus.cs
@@ -334,25 +334,19 @@ namespace DreadScripts.HierarchyPlus
 
 		        bool CanDrawIcon()
 		        {
+			        if (settings.alwaysShowIcons) return true;
 			        bool dotsOnly = iconsAreaWidth < 36;
 			        bool canDraw = iconsAreaWidth > 18;
-			        if (canDraw && dotsOnly && !settings.alwaysShowIcons)
+			        if (canDraw && dotsOnly)
 			        {
 				        GUI.Label(iconRect, "...", EditorStyles.centeredGreyMiniLabel);
 				        iconsAreaWidth -= 18;
 				        return false;
 			        }
 			        
-			        if (settings.alwaysShowIcons)
-			        {
-			        	iconsAreaWidth = 36;
-			        	return true;
-			        }
-			        else
-			        {
-			        	iconsAreaWidth -= 18;
-			        	return canDraw;
-			    	}
+			        iconsAreaWidth -= 18;
+			        return canDraw;
+			    	
 		        }
 
 		        if (settings.showGameObjectIcon && CanDrawIcon())

--- a/Editor/HierarchyPlus.cs
+++ b/Editor/HierarchyPlus.cs
@@ -353,8 +353,6 @@ namespace DreadScripts.HierarchyPlus
 			        	iconsAreaWidth -= 18;
 			        	return canDraw;
 			    	}
-
-			        
 		        }
 
 		        if (settings.showGameObjectIcon && CanDrawIcon())

--- a/Editor/SavedSettings.cs
+++ b/Editor/SavedSettings.cs
@@ -453,7 +453,8 @@ namespace DreadScripts.HierarchyPlus
 			useCustomGameObjectIcon = new SavedBool(true),
 			showTransformIcon = new SavedBool(false),
 			showNonBehaviourIcons = new SavedBool(true),
-			linkCursorOnHover = new SavedBool(false);
+			linkCursorOnHover = new SavedBool(false),
+			alwaysShowIcons = new SavedBool(false);
 		
 		[SerializeField] internal SavedFloat
 			guiXOffset = new SavedFloat(0);


### PR DESCRIPTION
This PR adds an option called "alwaysShowIcons".
It is made to address #12.

While functional, I am not really satisfied with it yet, as I would love the Icons to draw over, not under the text.
![image](https://github.com/Dreadrith/HierarchyPlus/assets/8122264/4b557771-b254-415d-a0cd-c94ab5a2a97a)


If this is all that was asked for, feel free to use this PR as a solution.