### PR TITLE
Use delayCall load icons

### DIFF
--- a/Editor/HierarchyPlus.cs
+++ b/Editor/HierarchyPlus.cs
@@ -789,7 +789,7 @@ namespace DreadScripts.HierarchyPlus
         [InitializeOnLoadMethod]
         private static void InitializeGUI()
         {
-            InitializeAll();
+            EditorApplication.delayCall += () => InitializeAll();
             EditorApplication.hierarchyWindowItemOnGUI -= OnHierarchyItemGUI;
             EditorApplication.hierarchyWindowItemOnGUI = OnHierarchyItemGUI + EditorApplication.hierarchyWindowItemOnGUI;
             EditorApplication.update -= OnCustomUpdate;
@@ -800,7 +800,7 @@ namespace DreadScripts.HierarchyPlus
 
         private static void InitializeAll()
         {
-	        iconCache.Clear();
+            iconCache.Clear();
             InitializeIconFolderPath();
             InitializeCustomIcons();
             InitializeSpecialIcons();


### PR DESCRIPTION
Use `delayCall` to load icons to avoid asset database not being initialized.